### PR TITLE
Pandas deprecation fixes

### DIFF
--- a/tests/region_remap_tests.py
+++ b/tests/region_remap_tests.py
@@ -30,15 +30,15 @@ class RemappingTests(unittest.TestCase):
             destination_platform=self.study.Annotations.cnv_ACGH_ANNOT.df,
             origin_platform=self.study.Annotations.rnaseq_RNASEQ_ANNOT.df
         )
-        assert remapped.ix[0, 0] == '_WASH7P'
-        assert (remapped.ix[:, 1] == [3.0, 38.5, 0.0, 1.0]).all()
+        assert remapped.iloc[0, 0] == '_WASH7P'
+        assert (remapped.iloc[:, 1] == [3.0, 38.5, 0.0, 1.0]).all()
 
     def test_remapping_shortcut(self):
         highdim_cnv = self.study.HighDim.cnv
         chrom_regions = self.study.Annotations.rnaseq_RNASEQ_ANNOT
         remapped = highdim_cnv.remap_to(destination=chrom_regions)
         assert remapped.dtypes[3] == 'int64'
-        assert (remapped.ix[:, 1] == [0, 0, 0, 1, 1]).all()
+        assert (remapped.iloc[:, 1] == [0, 0, 0, 1, 1]).all()
 
     def test_df_and_object_remap_input(self):
         highdim_cnv = self.study.HighDim.cnv

--- a/tmtk/annotation/ChromosomalRegions.py
+++ b/tmtk/annotation/ChromosomalRegions.py
@@ -8,4 +8,4 @@ class ChromosomalRegions(AnnotationBase):
 
     @property
     def biomarkers(self):
-        return self.df.ix[:, 1]
+        return self.df.iloc[:, 1]

--- a/tmtk/annotation/MicroarrayAnnotation.py
+++ b/tmtk/annotation/MicroarrayAnnotation.py
@@ -8,4 +8,4 @@ class MicroarrayAnnotation(AnnotationBase):
 
     @property
     def biomarkers(self):
-        return self.df.ix[:, 1]
+        return self.df.iloc[:, 1]

--- a/tmtk/annotation/MirnaAnnotation.py
+++ b/tmtk/annotation/MirnaAnnotation.py
@@ -8,4 +8,4 @@ class MirnaAnnotation(AnnotationBase):
 
     @property
     def biomarkers(self):
-        return self.df.ix[:, 0]
+        return self.df.iloc[:, 0]

--- a/tmtk/annotation/ProteomicsAnnotation.py
+++ b/tmtk/annotation/ProteomicsAnnotation.py
@@ -13,4 +13,4 @@ class ProteomicsAnnotation(AnnotationBase):
         if len(probeset_id_column) != 1:
             CPrint.error('Expected a probesetid column but got {}'.format(len(probeset_id_column)))
             return None
-        return self.df.ix[:, probeset_id_column[0]]
+        return self.df.loc[:, probeset_id_column[0]]

--- a/tmtk/arborist/jstreecontrol.py
+++ b/tmtk/arborist/jstreecontrol.py
@@ -31,8 +31,8 @@ def _get_hd_args(path, high_dim_node, annotation):
     """
     map_file = high_dim_node.sample_mapping
 
-    s = map_file.slice_path(path).ix[:, 5].unique()
-    t = map_file.slice_path(path).ix[:, 6].unique()
+    s = map_file.slice_path(path).iloc[:, 5].unique()
+    t = map_file.slice_path(path).iloc[:, 6].unique()
 
     hd_args = {'hd_sample': ', '.join(s.astype(str)) if pd.notnull(s[0]) else '',
                'hd_tissue': ', '.join(t.astype(str)) if pd.notnull(t[0]) else '',
@@ -209,7 +209,7 @@ class ConceptTree:
         # Fillna needs to happen because for some reason this expression below
         # returns True for NaN and NaN, which introduces unnecessary rows in word mapping.
         # This issue might need to be resolved earlier in the ConceptTree!
-        changed_values = df.fillna('').ix[:, 2] != df.fillna('').ix[:, 3]
+        changed_values = df.fillna('').iloc[:, 2] != df.fillna('').iloc[:, 3]
 
         # Set None to NaN, else empty fields in dataframes are not recognized (None != NaN)
         df.fillna(value=pd.np.nan, inplace=True)

--- a/tmtk/clinical/ColumnMapping.py
+++ b/tmtk/clinical/ColumnMapping.py
@@ -35,7 +35,7 @@ class ColumnMapping(FileBase):
     @property
     def included_datafiles(self):
         """List of datafiles included in column mapping file."""
-        return list(self.df.ix[:, 0].unique())
+        return list(self.df.iloc[:, 0].unique())
 
     @property
     def ids(self):
@@ -105,7 +105,7 @@ class ColumnMapping(FileBase):
         :return: `pd.DataFrame`.
         """
         df.fillna("", inplace=True)
-        df.ix[:, 2] = df.ix[:, 2].astype(int)
+        df.iloc[:, 2] = df.iloc[:, 2].astype(int)
         return df
 
     def build_index(self, df=None):
@@ -119,7 +119,7 @@ class ColumnMapping(FileBase):
         if not isinstance(df, pd.DataFrame):
             df = self.df
         df.set_index(list(df.columns[[0, 2]]), drop=False, inplace=True)
-        df.sortlevel(inplace=True)
+        df.sort_index(inplace=True)
         return df
 
     def append_from_datafile(self, datafile):

--- a/tmtk/clinical/Variable.py
+++ b/tmtk/clinical/Variable.py
@@ -96,7 +96,7 @@ class Variable:
 
         :return: All values as found in the datafile.
         """
-        return self.datafile.df.ix[:, self._zero_column]
+        return self.datafile.df.iloc[:, self._zero_column]
 
     @property
     def unique_values(self):

--- a/tmtk/clinical/WordMapping.py
+++ b/tmtk/clinical/WordMapping.py
@@ -52,7 +52,7 @@ class WordMapping(FileBase):
         if var_id in self.df.index:
             rows = self.df.loc[var_id]
             if isinstance(rows, pd.DataFrame):
-                return dict(zip(rows.ix[:, 2], rows.ix[:, 3]))
+                return dict(zip(rows.iloc[:, 2], rows.iloc[:, 3]))
             else:
                 return {rows[2]: rows[3]}
 
@@ -71,7 +71,7 @@ class WordMapping(FileBase):
         if not isinstance(df, pd.DataFrame):
             df = self.df
         df.set_index(list(df.columns[[0, 1]]), drop=False, inplace=True)
-        df.sortlevel(inplace=True)
+        df.sort_index(inplace=True)
         return df
 
     def create_df(self):
@@ -92,7 +92,7 @@ class WordMapping(FileBase):
         :param df: `pd.DataFrame`.
         :return: `pd.DataFrame`.
         """
-        df.ix[:, 1] = df.ix[:, 1].astype(int)
+        df.iloc[:, 1] = df.iloc[:, 1].astype(int)
         return df
 
     @property

--- a/tmtk/highdim/CopyNumberVariation.py
+++ b/tmtk/highdim/CopyNumberVariation.py
@@ -48,14 +48,14 @@ class CopyNumberVariation(HighDimBase):
 
         for sample in set(self.samples):
             columns = self.header.str.contains(sample + '.prob')
-            sample_df = self.df.ix[:, columns].astype(float)
+            sample_df = self.df.iloc[:, columns].astype(float)
             sample_df = sample_df.dropna()
             not_near_1 = ~sample_df.sum(axis=1).between(0.99, 1.01)
             if any(not_near_1):
                 everything_okay = False
                 bad_samples.append(sample)
                 [bad_regions.append(x) for x in
-                 self.df.ix[not_near_1, 0]]  # Adds region ids to list.
+                 self.df.loc[not_near_1, 0]]  # Adds region ids to list.
 
         if not everything_okay:
             m = 'Samples ({}) where have regions where CNV probabilities do not approximate 1. ' \

--- a/tmtk/highdim/HighDimBase.py
+++ b/tmtk/highdim/HighDimBase.py
@@ -54,7 +54,7 @@ class HighDimBase(utils.FileBase):
                 messages.error('No annotation file found for {}.'.format(self.platform))
             else:
                 messages.info('Annotation file found for {}, checking...'.format(self.platform))
-                data_series = self.df.ix[:, 0]
+                data_series = self.df.iloc[:, 0]
                 self._find_missing_annotation(annotation_series=self.annotation_file.biomarkers,
                                               data_series=data_series, messages=messages)
 

--- a/tmtk/highdim/SampleMapping.py
+++ b/tmtk/highdim/SampleMapping.py
@@ -30,21 +30,21 @@ class SampleMapping(FileBase):
 
     @staticmethod
     def _find_path(row):
-        cp = row.ix[8]
+        cp = row.iloc[8]
         # Legacy
-        cp = cp.replace('ATTR1', str(row.ix[6]))
-        cp = cp.replace('ATTR2', str(row.ix[7]))
+        cp = cp.replace('ATTR1', str(row.iloc[6]))
+        cp = cp.replace('ATTR2', str(row.iloc[7]))
 
         # Current
-        cp = cp.replace('PLATFORM', str(row.ix[4]))
-        cp = cp.replace('SAMPLETYPE', str(row.ix[5]))
-        cp = cp.replace('TISSUETYPE', str(row.ix[6]))
-        cp = cp.replace('TIMEPOINT', str(row.ix[7]))
+        cp = cp.replace('PLATFORM', str(row.iloc[4]))
+        cp = cp.replace('SAMPLETYPE', str(row.iloc[5]))
+        cp = cp.replace('TISSUETYPE', str(row.iloc[6]))
+        cp = cp.replace('TIMEPOINT', str(row.iloc[7]))
 
         return path_converter(cp)
 
     def update_concept_paths(self, path_dict):
-        self.df.ix[:, 8] = self.df.apply(lambda x: self._update_row(x, path_dict), axis=1)
+        self.df.iloc[:, 8] = self.df.apply(lambda x: self._update_row(x, path_dict), axis=1)
 
     def _update_row(self, row, path_dict):
         current_path = self._find_path(row)
@@ -66,14 +66,14 @@ class SampleMapping(FileBase):
 
     @property
     def samples(self):
-        return list(self.df.ix[:, 3])
+        return list(self.df.iloc[:, 3])
 
     @property
     def platform(self):
         """
         :return: the platform id in this sample mapping file.
         """
-        platform_ids = list(self.df.ix[:, 4].unique())
+        platform_ids = list(self.df.iloc[:, 4].unique())
         if len(platform_ids) > 1:
             CPrint.warn('Found multiple platforms in {}. '
                         'This might lead to unexpected behaviour.'.format(self.path))
@@ -86,7 +86,7 @@ class SampleMapping(FileBase):
 
         :return: study_id in sample mapping file
         """
-        study_ids = list(self.df.ix[:, 0].unique())
+        study_ids = list(self.df.iloc[:, 0].unique())
         if len(study_ids) > 1:
             CPrint.error('Found multiple study_ids found in {}. '
                          'This is not supported.'.format(self.path))
@@ -95,7 +95,7 @@ class SampleMapping(FileBase):
 
     @study_id.setter
     def study_id(self, value):
-        self.df.ix[:, 0] = value.upper()
+        self.df.iloc[:, 0] = value.upper()
 
     def slice_path(self, path):
         """
@@ -103,4 +103,4 @@ class SampleMapping(FileBase):
         :param path: path (will be converted using global logic).
         :return: slice of dataframe.
         """
-        return self.df.ix[self._converted_paths == path_converter(path), :]
+        return self.df.loc[self._converted_paths == path_converter(path), :]

--- a/tmtk/tags/Tags.py
+++ b/tmtk/tags/Tags.py
@@ -20,7 +20,7 @@ class MetaDataTags(FileBase):
         """
         Return tag paths delimited by the path_converter.
         """
-        return self.df.ix[:, 0].apply(lambda x: self._convert_path(x))
+        return self.df.iloc[:, 0].apply(lambda x: self._convert_path(x))
 
     @property
     def invalid_paths(self):

--- a/tmtk/toolbox/remap_chromosomal_regions.py
+++ b/tmtk/toolbox/remap_chromosomal_regions.py
@@ -5,10 +5,10 @@ def remap_chromosomal_regions(origin_platform=None, destination_platform=None, d
                               flag_indicator='.flag', to_dest=2, start_dest=3, end_dest=4,
                               region_dest=1, chr_origin=2, start_origin=3, end_origin=4,
                               region_origin=1, region_data=0):
-    dest_regions = destination_platform.ix[:, [to_dest, start_dest, end_dest]]
+    dest_regions = destination_platform.iloc[:, [to_dest, start_dest, end_dest]]
     dest_regions = _convert_xy_to_int(dest_regions)
 
-    orig_regions = origin_platform.ix[:, [chr_origin, start_origin, end_origin]]
+    orig_regions = origin_platform.iloc[:, [chr_origin, start_origin, end_origin]]
     orig_regions = _convert_xy_to_int(orig_regions)
 
     # Find overlapping regions
@@ -31,7 +31,7 @@ def remap_chromosomal_regions(origin_platform=None, destination_platform=None, d
     new_df = pd.DataFrame(columns=datafile.columns, data=remapped_regions)
 
     # Add back the region id's
-    new_df[segments_region_column] = destination_platform.ix[:, region_origin]
+    new_df[segments_region_column] = destination_platform.iloc[:, region_origin]
 
     # Convert flag columns to int
     if any(flag_columns):
@@ -63,7 +63,7 @@ def _convert_xy_to_int(df):
 
 
 def _find_overlapping_segments(chrom, start, end, regions):
-    which = (regions.ix[:, 0] == chrom) & (regions.ix[:, 2] >= start) & (regions.ix[:, 1] <= end)
+    which = (regions.iloc[:, 0] == chrom) & (regions.iloc[:, 2] >= start) & (regions.iloc[:, 1] <= end)
     selected_segments_index = regions.loc[which].index
     if len(selected_segments_index) > 0:
         return list(selected_segments_index)
@@ -82,14 +82,14 @@ def _map_multiple_segments_to_gene(from_regions, to_regions):
 def map_index_to_region_ids(gene, origin_platform, region_origin):
     mappings = []
     for i in gene:
-        mappings += [origin_platform.ix[i, region_origin]]
+        mappings += [origin_platform.iloc[i, region_origin]]
     return mappings
 
 
 def return_mean(datafile, mapping, flag_columns=None):
-    mapped_regions = pd.DataFrame(datafile[datafile.ix[:, 0].isin(mapping)])
-    mean_values = mapped_regions.ix[:, 1:].applymap(float).mean()
+    mapped_regions = pd.DataFrame(datafile[datafile.iloc[:, 0].isin(mapping)])
+    mean_values = mapped_regions.iloc[:, 1:].applymap(float).mean()
     if flag_columns.any() and (len(mapping) > 1):
-        mean_values[flag_columns] = (datafile[datafile.ix[:, 0].isin(mapping)][flag_columns]
+        mean_values[flag_columns] = (datafile[datafile.iloc[:, 0].isin(mapping)][flag_columns]
                                      ).apply(lambda x: pd.value_counts(x).index[0])
     return mean_values

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
-envlist=pandas0.19,pandas0.20
+envlist=pandas{0.19,0.20}
 
 [testenv]
 commands = coverage run --branch --omit={envdir}/*,tests/*.py -m unittest discover tests "*_tests.py"
-deps = coverage
-
-[testenv:pandas19]
-deps = pandas>=0.19.0, <0.20.0
-
-[testenv:pandas20]
-deps = pandas>=0.20.0, <0.21.0
+deps =
+    coverage
+    pandas0.19: pandas>=0.19.0,<0.20.0
+    pandas0.20: pandas>=0.20.0,<0.21.0


### PR DESCRIPTION
Pandas has deprecated .ix in favour of .loc and .iloc, .ix
should no longer be used after this.