### PR TITLE
Expand disallowed characters for namespace cleaning

### DIFF
--- a/tmtk/utils/Generic.py
+++ b/tmtk/utils/Generic.py
@@ -16,7 +16,7 @@ def clean_for_namespace(path) -> str:
     :param path: usually a descriptive subdirectory
     :return: string
     """
-    disallowed = ['/', '-', ' ', '.']
+    disallowed = ['/', '-', ' ', '.', '(', ')', '#']
     for item in disallowed:
         path = path.replace(item, '_')
     return path


### PR DESCRIPTION
Python dfs won't work in tmtk if name contains brackets.