### PR TITLE
Fix word_mapped_not_present method if the variable is not in the word map

### DIFF
--- a/tmtk/clinical/Variable.py
+++ b/tmtk/clinical/Variable.py
@@ -228,6 +228,9 @@ class Variable:
         return tuple(self.var_id) in self.parent.WordMapping.df.index
     
     def word_mapped_not_present(self):
+        if not self.is_in_wordmap:
+            return set()
+
         mapped_value_column = self.parent.WordMapping.df.columns[2]
         coordinates = (self.var_id.filename, self.var_id.column)
         mapped_values = self.parent.WordMapping.df.loc[coordinates,mapped_value_column]


### PR DESCRIPTION
You receive a keyError if you call the method and the variable is not in the word map.
So this seems cleaner. You get an empty set, because there exist no value that is word mapped but not present in the data file.