### PR TITLE
Study nodes without FAS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+.. topic::  Version 0.5.4
+
+    * Create transmart-copy files without setting ``FAS`` on study node.
+
 .. topic::  Version 0.5.2
 
     * You can now create a template from an existing tree in BaaS

--- a/tmtk/toolbox/skinny_loader/export_to_skinny.py
+++ b/tmtk/toolbox/skinny_loader/export_to_skinny.py
@@ -15,13 +15,32 @@ import os
 
 class SkinnyExport:
     """
-    This object creates pd.Dataframes that resemble tranSMART data base tables
-    by transforming the tmtk.Study object. The goal is to create files that can
-    be used by the skinny loader, which aims to do as little transformations as
-    possible.
+    This object creates tables like the tranSMART data base tables by
+    transforming the tmtk.Study object. The goal is to create files
+    that can be used as input files by the transmart-copy, which aims
+    to do as little transformations as possible.
+
+    see: https://github.com/thehyve/transmart-core/tree/dev/transmart-copy
     """
 
-    def __init__(self, study, export_directory=None, add_top_node=True):
+    def __init__(self, study, export_directory=None, add_top_node=True, omit_fas=False):
+        """
+        Create input files for transmart-copy.
+
+        Example usage:
+        ```
+            study = tmtk.Study('~/studies/GSE8581/study.params')
+            export = tmtk.toolbox.SkinnyExport(study, '/tmp/transmart-copy-ready/')
+            export.to_disk()
+        ```
+
+        :param study: ``tmtk.Study`` object needs to be transformed.
+        :param export_directory: destination directory for loadable files.
+        :param add_top_node: set to False to not add a study top node to all paths.
+            This prevents Glowing Bear from adding study constraints.
+        :param omit_fas: If True, include the top node, but add it as a normal folder instead
+            of a study node. This prevents Glowing Bear from adding study constraints.
+        """
         self.study = study
         self.export_directory = export_directory
 
@@ -29,7 +48,7 @@ class SkinnyExport:
         self.concept_dimension = ConceptDimension(self.study)
 
         # Nodes from concept dimension
-        self.i2b2_secure = I2B2Secure(self.study, self.concept_dimension, add_top_node)
+        self.i2b2_secure = I2B2Secure(self.study, self.concept_dimension, add_top_node, omit_fas)
 
         # First we build the patient_dimension and then the patient mapping based on that
         self.patient_dimension = PatientDimension(self.study)

--- a/tmtk/toolbox/skinny_loader/i2b2metadata/i2b2_secure.py
+++ b/tmtk/toolbox/skinny_loader/i2b2metadata/i2b2_secure.py
@@ -8,9 +8,10 @@ from hashlib import sha1
 
 class I2B2Secure(TableRow):
 
-    def __init__(self, study, concept_dimension, add_top_node=True):
+    def __init__(self, study, concept_dimension, add_top_node, omit_fas):
 
         self.study = study
+        self.omit_fas = omit_fas
 
         if not add_top_node:
             study.top_node = '\\'
@@ -65,7 +66,7 @@ class I2B2Secure(TableRow):
 
         row.c_fullname = self.sanitize_path(self.study.top_node)
         row.c_hlevel = calc_hlevel(row.c_fullname)
-        row.c_visualattributes = 'FAS'
+        row.c_visualattributes = 'FA' if self.omit_fas else 'FAS'
         row.c_facttablecolumn = '@'
         row.c_tablename = 'STUDY'
         row.c_columnname = 'STUDY_ID'

--- a/tmtk/version.py
+++ b/tmtk/version.py
@@ -4,5 +4,5 @@ This file is distributed under the GNU General Public License
   (see accompanying file LICENSE).
 """
 
-version_info = (0, 5, 3)
+version_info = (0, 5, 4)
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Create transmart-copy input files without setting FAS on study node.