### PR TITLE
Template reader column reuse

### DIFF
--- a/tests/template_reader_tests.py
+++ b/tests/template_reader_tests.py
@@ -63,7 +63,9 @@ class TemplateReaderTests(TestBase):
     def test_value_substitution_sheet(self):
         value_substitution_sheet = ValueSubstitutionSheet(self.template.parse('Value substitution', comment=COMMENT))
         self.assertTupleEqual(value_substitution_sheet.df.shape, (6, 4))
-        key_set = {'Gender', 'QLQ-C30_Q01', 'QLQ-C30_Q02', 'QLQ-C30_Q03', 'QLQ-C30_Q04'}
+        key_set = {('Gender', 'Low-dimensional data (Mock)'), ('QLQ-C30_Q01', 'TRIAL_VISIT_Data (Mock)'),
+                   ('QLQ-C30_Q02', 'TRIAL_VISIT_Data (Mock)'), ('QLQ-C30_Q03', 'TRIAL_VISIT_Data (Mock)'),
+                   ('QLQ-C30_Q04', 'TRIAL_VISIT_Data (Mock)')}
         self.assertSequenceEqual(value_substitution_sheet.word_map.keys(), key_set)
 
     def test_trial_visit_sheet(self):
@@ -95,17 +97,17 @@ class TemplateReaderTests(TestBase):
     def test_blue_print_file(self):
         tree_sheet = TreeSheet(self.template.parse('Tree structure', comment=COMMENT))
         b = BlueprintFile(tree_sheet)
-        self.assertIn('Blood_Volume', b.blueprint)
+        self.assertIn(('Blood_Volume', 'SAMPLE (Mock)'), b.blueprint)
         self.assertEqual(len(b.blueprint), 29)
         self.assertDictEqual(
             {
                 'label': 'Blood volume',
                 'path': '3. Biobank\\Blood'
             },
-            b.blueprint['Blood_Volume']
+            b.blueprint[('Blood_Volume', 'SAMPLE (Mock)')]
         )
 
-        update_item = {'Blood_Volume':
+        update_item = {('Blood_Volume', 'SAMPLE (Mock)'):
             {
                 'label': 'Volume of blood',
                 'path': '3. Biobank',
@@ -119,10 +121,10 @@ class TemplateReaderTests(TestBase):
                 'path': '3. Biobank',
                 'new_item': 'test'
             },
-            b.blueprint['Blood_Volume']
+            b.blueprint[('Blood_Volume', 'SAMPLE (Mock)')]
         )
 
-        new_item = {'test_item':
+        new_item = {'RESERVED_KEYWORD':
             {
                 'label': 'this is a test',
                 'path': 'some path',
@@ -134,7 +136,7 @@ class TemplateReaderTests(TestBase):
             {
                 'label': 'this is a test',
                 'path': 'some path',
-            }, b.blueprint['test_item']
+            }, b.blueprint['RESERVED_KEYWORD']
         )
 
     def test_template_reader(self):

--- a/tmtk/clinical/Clinical.py
+++ b/tmtk/clinical/Clinical.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 import pandas as pd
 
 import tmtk
@@ -101,9 +103,14 @@ class Clinical(ValidateMixin):
         :param omit_missing: if True, then variable that are not present in the blueprint
         will be set to OMIT.
         """
-        for var_id, variable in self.all_variables.items():
+        for variable in self.all_variables.values():
+            # The default blueprint key is a tuple containing the column name and the file name (without extension)
+            blueprint_key = (variable.header.strip(), Path(variable.filename).stem)
+            if blueprint_key not in blueprint:
+                # Fallback to assuming a reserved keyword column (key is only the reserved keyword)
+                blueprint_key = blueprint_key[0]
 
-            blueprint_var = blueprint.get(variable.header.strip())
+            blueprint_var = blueprint.get(blueprint_key)
 
             if not blueprint_var:
                 self.msgs.info("Column with header {!r}. Not found in blueprint.".format(variable.header))

--- a/tmtk/clinical/Clinical.py
+++ b/tmtk/clinical/Clinical.py
@@ -107,7 +107,7 @@ class Clinical(ValidateMixin):
             # The default blueprint key is a tuple containing the column name and the file name (without extension)
             blueprint_key = (variable.header.strip(), Path(variable.filename).stem)
             if blueprint_key not in blueprint:
-                # Fallback to assuming a reserved keyword column (key is only the reserved keyword)
+                # Fallback to assuming a column-name-only key
                 blueprint_key = blueprint_key[0]
 
             blueprint_var = blueprint.get(blueprint_key)

--- a/tmtk/tags/Tags.py
+++ b/tmtk/tags/Tags.py
@@ -84,6 +84,10 @@ class MetaDataTags(FileBase, ValidateMixin):
         for variable in self.parent.Clinical.all_variables.values():
             # The default blueprint key is a tuple containing the column name and the file name (without extension)
             blueprint_key = (variable.header.strip(), Path(variable.filename).stem)
+            if blueprint_key not in blueprint:
+                # Fallback to assuming a column-name-only key
+                blueprint_key = blueprint_key[0]
+
             blueprint_var = blueprint.get(blueprint_key, {})
             tags = blueprint_var.get('metadata_tags')
             if not tags:

--- a/tmtk/tags/Tags.py
+++ b/tmtk/tags/Tags.py
@@ -1,7 +1,10 @@
-import pandas as pd
 import os
-from ..utils import Exceptions, FileBase, Mappings, path_converter, TransmartBatch, ValidateMixin, path_join
+from pathlib import Path
+
+import pandas as pd
+
 from ..params import TagsParams
+from ..utils import Exceptions, FileBase, Mappings, path_converter, TransmartBatch, ValidateMixin, path_join
 
 
 class MetaDataTags(FileBase, ValidateMixin):
@@ -78,8 +81,10 @@ class MetaDataTags(FileBase, ValidateMixin):
 
         :param blueprint: blueprint object.
         """
-        for var in self.parent.Clinical.all_variables.values():
-            blueprint_var = blueprint.get(var.header, {})
+        for variable in self.parent.Clinical.all_variables.values():
+            # The default blueprint key is a tuple containing the column name and the file name (without extension)
+            blueprint_key = (variable.header.strip(), Path(variable.filename).stem)
+            blueprint_var = blueprint.get(blueprint_key, {})
             tags = blueprint_var.get('metadata_tags')
             if not tags:
                 continue


### PR DESCRIPTION
Update the blueprint and template reader functionality such that column names no longer have to be unique across data source files (only within a file). The key of the blueprint dictionary is therefore modified to a tuple containing the column name and the file name (instead of just column name).