### PR TITLE
Add end dates to observation fact table

### DIFF
--- a/tests/skinny_loader_tests.py
+++ b/tests/skinny_loader_tests.py
@@ -28,6 +28,18 @@ class SkinnyTests(TestBase):
         df = self.export.observation_fact.df
         self.assertEqual(len(set(df[df.modifier_cd == 'TRANSMART:SAMPLE_CODE']['instance_num'])), 2)
 
+    def test_start_date_in_observation_fact(self):
+        start_date_series = pd.to_datetime(self.export.observation_fact.df['start_date'])
+        self.assertEqual(sum(start_date_series.isnull()), 0)
+        self.assertEqual(max(start_date_series).date(), pd.to_datetime('2016-04-19').date())
+        self.assertEqual(min(start_date_series).date(), pd.to_datetime('2016-02-26').date())
+
+    def test_end_date_in_observation_fact(self):
+        end_date_series = pd.to_datetime(self.export.observation_fact.df['end_date'])
+        self.assertEqual(sum(end_date_series.isnull()), 413)
+        self.assertEqual(max(end_date_series.dropna()).date(), pd.to_datetime('2016-04-07').date())
+        self.assertEqual(min(end_date_series.dropna()).date(), pd.to_datetime('2016-03-02').date())
+
     def test_trial_visit_dimension(self):
         df = self.export.trial_visit_dimension.df
         self.assertEqual(df.shape[0], 8)

--- a/tmtk/toolbox/skinny_loader/i2b2demodata/observation_fact.py
+++ b/tmtk/toolbox/skinny_loader/i2b2demodata/observation_fact.py
@@ -80,6 +80,7 @@ class ObservationFact(TableRow):
         # Preload these, so we don't have to get them for every value in the current variable
         modifiers = var.modifiers
         start_date = var.start_date
+        end_date = var.end_date
 
         if var.trial_visit:
             trial_visit_num = var.trial_visit.values.map(self.skinny.trial_visit_dimension.get_num)
@@ -106,6 +107,7 @@ class ObservationFact(TableRow):
             'concept_cd': var.concept_code or self.skinny.concept_dimension.map.get(var_full_path),
             'provider_id': '@',
             'start_date': start_date.values if start_date else None,
+            'end_date': end_date.values if end_date else None,
             'modifier_cd': '@',
             'trial_visit_num': trial_visit_num,
             # because of poorly suited primary key on observation_fact


### PR DESCRIPTION
- Include end dates into the observation fact table created by skinnyExport
- Add unit tests for presence of start and end dates