### PR TITLE
Add dimension_type and sort_index to dimension_description

### DIFF
--- a/docs/data_formats/clinical.rst
+++ b/docs/data_formats/clinical.rst
@@ -159,21 +159,23 @@ Example trial visit file:
 
 Modifier file
 '''''''''''''
-A tab separated file with **four** columns:
+A tab separated file with **six** columns:
 
 * ``Modifier path``. Path of the modifier.
 * ``Modifier code``. Unique modifier code. Used in the **column mapping file** as ``Concept type``
 * ``Name charater``. Label of the modifier
 * ``Data type``. Data type of the modifier, options *CATEGORICAL* or *NUMERICAL*
+* ``dimension_type``. Indicates whether the dimension represents subjects or observation attributes, options *SUBJECT* or *ATTRIBUTE* (optional).
+* ``sort_index``. Specifies a relative order between dimensions (optional).
 
-+---------+---------+------------------------+-----------+
-|modifier |modifier |name                    |data       |
-|path     |code     |char                    |type       |
-+=========+=========+========================+===========+
-|\\Dose   |DOSE     | Drug dose administered |NUMERICAL  |
-+---------+---------+------------------------+-----------+
-|\\Samples|SAMPLE_ID| Modifier for Samples   |CATEGORICAL|
-+---------+---------+------------------------+-----------+ 
++---------+---------+------------------------+-----------+---------+-----+
+|modifier |modifier |name                    |data       |dimension|sort |
+|path     |code     |char                    |type       |type     |index|
++=========+=========+========================+===========+=========+=====+
+|\\Dose   |DOSE     | Drug dose administered |NUMERICAL  | SUBJECT | 2   |
++---------+---------+------------------------+-----------+---------+-----+
+|\\Samples|SAMPLE_ID| Modifier for Samples   |CATEGORICAL| SUBJECT | 3   |
++---------+---------+------------------------+-----------+---------+-----+
 
 
 .. _ontology_file_format:

--- a/docs/data_formats/clinical.rst
+++ b/docs/data_formats/clinical.rst
@@ -164,7 +164,7 @@ A tab separated file with **six** columns:
 * ``Modifier path``. Path of the modifier.
 * ``Modifier code``. Unique modifier code. Used in the **column mapping file** as ``Concept type``
 * ``Name charater``. Label of the modifier
-* ``Data type``. Data type of the modifier, options *CATEGORICAL* or *NUMERICAL*
+* ``Data Type``. Data type of the modifier, options *CATEGORICAL* or *NUMERICAL*
 * ``dimension_type``. Indicates whether the dimension represents subjects or observation attributes, options *SUBJECT* or *ATTRIBUTE* (optional).
 * ``sort_index``. Specifies a relative order between dimensions (optional).
 

--- a/studies/TEST_17_1/clinical/modifiers.txt
+++ b/studies/TEST_17_1/clinical/modifiers.txt
@@ -1,2 +1,2 @@
-modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+modifier_path	modifier_cd	name_char	Data Type	dimension_type	sort_index
 \Sample Code	TRANSMART:SAMPLE_CODE	sample_code	CATEGORICAL	SUBJECT	2

--- a/studies/TEST_17_1/clinical/modifiers.txt
+++ b/studies/TEST_17_1/clinical/modifiers.txt
@@ -1,2 +1,2 @@
-modifier_path	modifier_cd	name_char	Data type
-\Sample Code	TRANSMART:SAMPLE_CODE	sample_code	CATEGORICAL
+modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+\Sample Code	TRANSMART:SAMPLE_CODE	sample_code	CATEGORICAL	SUBJECT	2

--- a/studies/blueprinted_modifier/modifiers.txt
+++ b/studies/blueprinted_modifier/modifiers.txt
@@ -1,3 +1,3 @@
-modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+modifier_path	modifier_cd	name_char	Data Type	dimension_type	sort_index
 \Test mod Code	TEST_MOD	test_mod	CATEGORICAL		
 \Test single mod Code	TEST_MOD_SINGLE	test_mod_single	CATEGORICAL		

--- a/studies/blueprinted_modifier/modifiers.txt
+++ b/studies/blueprinted_modifier/modifiers.txt
@@ -1,3 +1,3 @@
-modifier_path	modifier_cd	name_char	Data type
-\Test mod Code	TEST_MOD	test_mod	CATEGORICAL
-\Test single mod Code	TEST_MOD_SINGLE	test_mod_single	CATEGORICAL
+modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+\Test mod Code	TEST_MOD	test_mod	CATEGORICAL		
+\Test single mod Code	TEST_MOD_SINGLE	test_mod_single	CATEGORICAL		

--- a/studies/survey/clinical/modifiers_file.txt
+++ b/studies/survey/clinical/modifiers_file.txt
@@ -1,2 +1,2 @@
-modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+modifier_path	modifier_cd	name_char	Data Type	dimension_type	sort_index
 \Missing Value	MISSVAL	Missing Value	CATEGORICAL		

--- a/studies/survey/clinical/modifiers_file.txt
+++ b/studies/survey/clinical/modifiers_file.txt
@@ -1,2 +1,2 @@
-modifier_path	modifier_cd	name_char	Data Type
-\Missing Value	MISSVAL	Missing Value	CATEGORICAL
+modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+\Missing Value	MISSVAL	Missing Value	CATEGORICAL		

--- a/studies/valid_study/clinical/modifiers_file.txt
+++ b/studies/valid_study/clinical/modifiers_file.txt
@@ -1,1 +1,1 @@
-modifier_path	modifier_cd	name_char	Data Type
+modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index

--- a/studies/valid_study/clinical/modifiers_file.txt
+++ b/studies/valid_study/clinical/modifiers_file.txt
@@ -1,1 +1,1 @@
-modifier_path	modifier_cd	name_char	Data type	dimension_type	sort_index
+modifier_path	modifier_cd	name_char	Data Type	dimension_type	sort_index

--- a/tests/skinny_loader_tests.py
+++ b/tests/skinny_loader_tests.py
@@ -51,3 +51,14 @@ class SkinnyTests(TestBase):
         nr_of_nodes = self.export.i2b2_secure.df.shape[0]
         self.export2 = tmtk.toolbox.SkinnyExport(self.study, self.temp_dir, add_top_node=False)
         self.assertEqual(nr_of_nodes-2, self.export2.i2b2_secure.df.shape[0])
+
+    def test_dimension_description(self):
+        df = self.export.dimension_description.df
+        modifier_dimension_type = df.loc[df.modifier_code == 'TRANSMART:SAMPLE_CODE', 'dimension_type'].values[0]
+        modifier_sort_index = df.loc[df.modifier_code == 'TRANSMART:SAMPLE_CODE', 'sort_index'].values[0]
+        patient_dimension_type = df.loc[df.name == 'patient', 'dimension_type'].values[0]
+        patient_sort_index = df.loc[df.name == 'patient', 'sort_index'].values[0]
+        self.assertEqual(modifier_dimension_type, 'SUBJECT')
+        self.assertEqual(modifier_sort_index, '2')
+        self.assertEqual(patient_dimension_type, 'SUBJECT')
+        self.assertEqual(patient_sort_index, '1')

--- a/tests/template_reader_tests.py
+++ b/tests/template_reader_tests.py
@@ -47,7 +47,7 @@ class TemplateReaderTests(TestBase):
 
     def test_modifier_sheet(self):
         modifier_sheet = ModifierSheet(self.template.parse('Modifier', comment=COMMENT))
-        self.assertTupleEqual(modifier_sheet.df.shape, (3, 4))
+        self.assertTupleEqual(modifier_sheet.df.shape, (3, 6))
         self.assertDictEqual(modifier_sheet.modifier_blueprint, {})
 
         modifier_sheet.set_initial_modifier_blueprint(self.study.Clinical.Modifiers.df)

--- a/tmtk/clinical/modifier.py
+++ b/tmtk/clinical/modifier.py
@@ -55,7 +55,9 @@ class Modifiers(FileBase):
                               'modifier_path': ['\Missing Value', '\Sample_id'],
                               'modifier_cd': ['MISSVAL', 'SAMPLE_ID'],
                               'name_char': ['Missing Value','Sample identifier'],
-                              'Data Type': ['CATEGORICAL', 'CATEGORICAL']}
+                              'Data Type': ['CATEGORICAL', 'CATEGORICAL'],
+                              'dimension_type': ['ATTRIBUTE', 'SUBJECT'],
+                              'sort_index': [3, 2]}
                           )
         df = self.build_index(df)
         return df

--- a/tmtk/toolbox/skinny_loader/i2b2metadata/dimension_descriptions.py
+++ b/tmtk/toolbox/skinny_loader/i2b2metadata/dimension_descriptions.py
@@ -23,6 +23,12 @@ class DimensionDescription(TableRow):
         # Cannot use dot notation here because name is an attribute of
         # pd.Series and that causes a collision.
         row['name'] = dimension
+
+        # Hardcoded patient dimension properties
+        if dimension == 'patient':
+            row['dimension_type'] = 'SUBJECT'
+            row['sort_index'] = '1'
+
         return row
 
     def adapt_rows_from_modifier_dimension(self):
@@ -33,8 +39,13 @@ class DimensionDescription(TableRow):
             if not any(modifier_row):
                 return
 
+            size = len(x)
             self.df.loc[modifier_row, 'modifier_code'] = x[1]
             self.df.loc[modifier_row, 'value_type'] = 'T' if x[3] == 'CATEGORICAL' else 'N'
+            if size > 4:
+                self.df.loc[modifier_row, 'dimension_type'] = x[4]
+            if size > 5:
+                self.df.loc[modifier_row, 'sort_index'] = x[5]
 
             # Some hardcoded stuff
             self.df.loc[modifier_row, 'density'] = 'DENSE'
@@ -55,6 +66,8 @@ class DimensionDescription(TableRow):
                 None,  # name
                 None,  # packable
                 None,  # size_cd
+                None,  # dimension_type
+                None,  # sort_index
             ],
             index=[
                 'id',
@@ -64,4 +77,6 @@ class DimensionDescription(TableRow):
                 'name',
                 'packable',
                 'size_cd',
+                'dimension_type',
+                'sort_index'
             ])

--- a/tmtk/toolbox/template_reader/sheets.py
+++ b/tmtk/toolbox/template_reader/sheets.py
@@ -120,6 +120,11 @@ class ModifierSheet:
         self.df.columns = lower_columns
         self.df.rename(columns=self.modifier_column_map, inplace=True)
         self.df['modifier_path'] = self.df['modifier_cd']
+
+        # optional values
+        self.df['dimension_type'] = pd.np.NaN
+        self.df['sort_index'] = pd.np.NaN
+
         self.df = self.df[Mappings.modifiers_header]
         self.df.set_index('modifier_cd', drop=False, inplace=True)
         self.modifier_blueprint = {}

--- a/tmtk/utils/mappings.py
+++ b/tmtk/utils/mappings.py
@@ -28,6 +28,8 @@ class Mappings:
     modifier_cd = 'modifier_cd'
     name_char = 'name_char'
     column_type = 'Data Type'
+    dimension_type = "dimension_type"
+    sort_index = 'sort_index'
 
     # Ontology file
     term_label = 'Label'
@@ -87,7 +89,9 @@ class Mappings:
     modifiers_header = [modifier_path,
                         modifier_cd,
                         name_char,
-                        column_type]
+                        column_type,
+                        dimension_type,
+                        sort_index]
 
     ontology_header = [ontology_code,
                        term_label,


### PR DESCRIPTION
There are 2 new columns in dimension description introduced in [transmart 17.1-HYVE-5.8-RC1](https://github.com/thehyve/transmart-core/releases/tag/v17.1-hyve-5.8-rc.1), related to the sample based querying support:
- dimension description - Indicates whether the dimension represents subjects or observation attributes. [SUBJECT, ATTRIBUTE],
- sort index - Specifies a relative order between dimensions.

Issue description: [TMT-858](https://jira.thehyve.nl/browse/TMT-858).
Related conversion pipline PR: https://github.com/thehyve/pmc-conversion/pull/71